### PR TITLE
Add scheduled garbage collection for Rust target directories

### DIFF
--- a/rust/cargo-sweep-gc
+++ b/rust/cargo-sweep-gc
@@ -9,7 +9,7 @@
 # Configuration (all optional, override in the environment):
 #   CARGO_SWEEP_ROOTS   colon-separated dirs to sweep  (default: $HOME/Documents)
 #   CARGO_SWEEP_DAYS    age threshold in days          (default: 15)
-#   CARGO_SWEEP_MAXSIZE per-target ceiling in MB       (default: 25000)
+#   CARGO_SWEEP_MAXSIZE per-target ceiling in MB       (default: unset, off)
 #   CARGO_SWEEP_LOG     log file                       (default: ~/.cache/cargo-sweep.log)
 #   CARGO_SWEEP_DRYRUN  set to 1 to report without deleting
 #
@@ -21,7 +21,7 @@ set -eu
 
 ROOTS="${CARGO_SWEEP_ROOTS:-$HOME/Documents}"
 DAYS="${CARGO_SWEEP_DAYS:-15}"
-MAXSIZE="${CARGO_SWEEP_MAXSIZE:-25000}"
+MAXSIZE="${CARGO_SWEEP_MAXSIZE:-}"
 LOG="${CARGO_SWEEP_LOG:-$HOME/.cache/cargo-sweep.log}"
 DRY=""
 [ "${CARGO_SWEEP_DRYRUN:-0}" = "1" ] && DRY="--dry-run"
@@ -81,10 +81,14 @@ for root in $ROOTS; do
   # toolchain that nothing has referenced in a while.
   "$CARGO" sweep --time "$DAYS" --recursive $DRY "$root" >>"$LOG" 2>&1 || log "  warn: --time failed in $root"
 
-  # Age alone does not bound a directory that churns faster than it ages. The
-  # ceiling only ever engages on a runaway target, since a complete build of
-  # even a large workspace lands far below it. Artifacts removed here are
-  # rebuilt on demand, so the cost of a false positive is build time.
+  # Optional hard ceiling, off by default. Age alone does not bound a directory
+  # that churns faster than it ages, but this pass is easy to set too low:
+  # cargo-sweep measures apparent file size, not the allocated size df and du
+  # report. One workspace here measures 20.9 GiB by du and 32.9 GiB by
+  # cargo-sweep, so a ceiling chosen against du trims a healthy tree on every
+  # run and forces needless rebuilds. Measure the target with
+  # `cargo sweep --maxsize N --dry-run` and pick a value above what a settled
+  # tree reports before enabling this.
   if [ -n "$MAXSIZE" ]; then
     "$CARGO" sweep --maxsize "$MAXSIZE" --recursive $DRY "$root" >>"$LOG" 2>&1 || log "  warn: --maxsize failed in $root"
   fi

--- a/rust/cargo-sweep-gc
+++ b/rust/cargo-sweep-gc
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Bounded garbage collection for Rust target/ directories.
+#
+# Cargo never removes stale build artifacts. Every dependency bump, feature
+# change, or branch switch writes a new fingerprint into target/debug/deps/ and
+# leaves every predecessor in place, so a target/ dir only ever grows. This
+# reclaims the artifacts nothing references any more.
+#
+# Configuration (all optional, override in the environment):
+#   CARGO_SWEEP_ROOTS   colon-separated dirs to sweep  (default: $HOME/Documents)
+#   CARGO_SWEEP_DAYS    age threshold in days          (default: 15)
+#   CARGO_SWEEP_MAXSIZE per-target ceiling in MB       (default: 25000)
+#   CARGO_SWEEP_LOG     log file                       (default: ~/.cache/cargo-sweep.log)
+#   CARGO_SWEEP_DRYRUN  set to 1 to report without deleting
+#
+# Note on --time: cargo-sweep reads timestamps from cargo's own fingerprint
+# metadata rather than file mtime, so touching files does not age them and a
+# freshly rebuilt tree correctly sweeps to nothing.
+
+set -eu
+
+ROOTS="${CARGO_SWEEP_ROOTS:-$HOME/Documents}"
+DAYS="${CARGO_SWEEP_DAYS:-15}"
+MAXSIZE="${CARGO_SWEEP_MAXSIZE:-25000}"
+LOG="${CARGO_SWEEP_LOG:-$HOME/.cache/cargo-sweep.log}"
+DRY=""
+[ "${CARGO_SWEEP_DRYRUN:-0}" = "1" ] && DRY="--dry-run"
+
+# launchd gives a minimal PATH, so locate cargo explicitly.
+CARGO="${CARGO_BIN:-$HOME/.cargo/bin/cargo}"
+[ -x "$CARGO" ] || CARGO="$(command -v cargo 2>/dev/null || true)"
+
+mkdir -p "$(dirname "$LOG")"
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >>"$LOG"; }
+
+if [ -z "$CARGO" ] || [ ! -x "$CARGO" ]; then
+  log "abort: cargo not found"
+  exit 1
+fi
+
+# A sweep during a live build can delete an artifact rustc is still linking
+# against. Parallel agent sessions make that a routine state, not a rare one,
+# so bail rather than risk corrupting a build in progress.
+#
+# Match on the basename so that cargo subcommand binaries are caught too. A
+# plain "cargo" check misses cargo-zigbuild, cargo-nextest and every other
+# cargo-* wrapper, all of which drive real builds. rust-analyzer itself is
+# excluded deliberately, since it is a long-lived language server that would
+# block the sweep for as long as an editor stays open. The rustc processes it
+# spawns for checks are still caught.
+build_running() {
+  ps -eo comm= 2>/dev/null | sed 's|.*/||' | grep -qE '^(rustc|cargo|cargo-[A-Za-z0-9_-]+)$'
+}
+
+if build_running; then
+  log "skipped: build in progress"
+  exit 0
+fi
+
+before=$(df -k "$HOME" | tail -1 | awk '{print $4}')
+log "start (roots=$ROOTS days=$DAYS${DRY:+ DRY-RUN})"
+
+OLDIFS=$IFS
+IFS=':'
+for root in $ROOTS; do
+  IFS=$OLDIFS
+  [ -d "$root" ] || { log "  skip missing root: $root"; IFS=':'; continue; }
+
+  # Re-check per root. A build can start after the initial check, and this
+  # narrows that window rather than closing it. The residual race is bounded:
+  # cargo rebuilds whatever was removed, so the worst case is lost build time.
+  if build_running; then
+    log "  stopped at $root: build started"
+    break
+  fi
+
+  # --installed drops artifacts built by toolchains rustup no longer has.
+  "$CARGO" sweep --installed --recursive $DRY "$root" >>"$LOG" 2>&1 || log "  warn: --installed failed in $root"
+
+  # --time catches the dominant case: stale fingerprints from the *same*
+  # toolchain that nothing has referenced in a while.
+  "$CARGO" sweep --time "$DAYS" --recursive $DRY "$root" >>"$LOG" 2>&1 || log "  warn: --time failed in $root"
+
+  # Age alone does not bound a directory that churns faster than it ages. The
+  # ceiling only ever engages on a runaway target, since a complete build of
+  # even a large workspace lands far below it. Artifacts removed here are
+  # rebuilt on demand, so the cost of a false positive is build time.
+  if [ -n "$MAXSIZE" ]; then
+    "$CARGO" sweep --maxsize "$MAXSIZE" --recursive $DRY "$root" >>"$LOG" 2>&1 || log "  warn: --maxsize failed in $root"
+  fi
+
+  IFS=':'
+done
+IFS=$OLDIFS
+
+if [ -n "$DRY" ]; then
+  # Free space moves on its own while other work runs, so a delta measured
+  # during a dry run would report a reclaim that never happened.
+  log "done (dry run, nothing deleted)"
+else
+  after=$(df -k "$HOME" | tail -1 | awk '{print $4}')
+  log "done (reclaimed $(( (after - before) / 1024 )) MiB)"
+fi

--- a/rust/target-gc.sh
+++ b/rust/target-gc.sh
@@ -20,7 +20,7 @@ PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
 # Sweep these roots. Override per machine if repos live elsewhere.
 SWEEP_ROOTS="${CARGO_SWEEP_ROOTS:-$HOME/Documents}"
 SWEEP_DAYS="${CARGO_SWEEP_DAYS:-15}"
-SWEEP_MAXSIZE="${CARGO_SWEEP_MAXSIZE:-25000}"
+SWEEP_MAXSIZE="${CARGO_SWEEP_MAXSIZE:-}"
 
 echo "==> installing cargo-sweep"
 if command -v cargo-sweep >/dev/null 2>&1; then

--- a/rust/target-gc.sh
+++ b/rust/target-gc.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Keep Rust target/ directories from growing without bound.
+#
+# Cargo never removes stale build artifacts. Every dependency bump, feature
+# change, or branch switch writes a fresh fingerprint into target/debug/deps/
+# and leaves every predecessor behind, so target/ only ever grows. On a machine
+# running several repos this reaches hundreds of gigabytes.
+#
+# Run once per machine. The per-repo [profile.dev] settings that pair with this
+# live in each repo's Cargo.toml and arrive over git.
+
+set -euo pipefail
+
+DOTTY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$HOME/.local/bin"
+LABEL="dev.local.cargo-sweep-gc"
+PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# Sweep these roots. Override per machine if repos live elsewhere.
+SWEEP_ROOTS="${CARGO_SWEEP_ROOTS:-$HOME/Documents}"
+SWEEP_DAYS="${CARGO_SWEEP_DAYS:-15}"
+SWEEP_MAXSIZE="${CARGO_SWEEP_MAXSIZE:-25000}"
+
+echo "==> installing cargo-sweep"
+if command -v cargo-sweep >/dev/null 2>&1; then
+  echo "    already present"
+else
+  cargo install cargo-sweep
+fi
+
+echo "==> linking cargo-sweep-gc into $BIN_DIR"
+mkdir -p "$BIN_DIR"
+ln -sf "$DOTTY_DIR/cargo-sweep-gc" "$BIN_DIR/cargo-sweep-gc"
+
+case "$(uname -s)" in
+  Darwin)
+    echo "==> installing launchd agent ($LABEL)"
+    mkdir -p "$(dirname "$PLIST")"
+    cat >"$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${BIN_DIR}/cargo-sweep-gc</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CARGO_SWEEP_ROOTS</key>
+        <string>${SWEEP_ROOTS}</string>
+        <key>CARGO_SWEEP_DAYS</key>
+        <string>${SWEEP_DAYS}</string>
+        <key>CARGO_SWEEP_MAXSIZE</key>
+        <string>${SWEEP_MAXSIZE}</string>
+    </dict>
+    <key>StartInterval</key>
+    <integer>21600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>Nice</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>${HOME}/.cache/cargo-sweep-launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>${HOME}/.cache/cargo-sweep-launchd.log</string>
+</dict>
+</plist>
+PLIST_EOF
+
+    launchctl unload "$PLIST" 2>/dev/null || true
+    launchctl load "$PLIST"
+    echo "    loaded, runs every 6 hours"
+    ;;
+  Linux)
+    echo "==> Linux: add a timer or cron entry for $BIN_DIR/cargo-sweep-gc"
+    echo "    suggested: 0 */6 * * * $BIN_DIR/cargo-sweep-gc"
+    ;;
+esac
+
+echo
+echo "Done. Verify with a dry run (reports without deleting):"
+echo "  CARGO_SWEEP_DRYRUN=1 $BIN_DIR/cargo-sweep-gc && tail ~/.cache/cargo-sweep.log"
+echo
+echo "The script refuses to run while cargo or rustc is active, so a dry run"
+echo "during a build reports 'skipped: build in progress' rather than sweeping."


### PR DESCRIPTION
Cargo never removes stale build artifacts. Every dependency bump, feature change, or branch switch writes a new fingerprint into `target/debug/deps` and leaves every predecessor in place, so a target directory only ever grows. Across several repos this reached ~197 GiB on one machine.

`cargo-sweep-gc` wraps cargo-sweep with two passes: drop artifacts from toolchains rustup no longer has, and drop fingerprints nothing has referenced in 15 days.

It refuses to run while a build is active. The guard matches on process basename so cargo subcommand wrappers such as `cargo-zigbuild` are caught, and deliberately excludes `rust-analyzer`, which would otherwise block the sweep for as long as an editor stays open.

`target-gc.sh` installs it per machine and takes the sweep roots as configuration so a machine that lays repos out differently still works.

An optional per-directory size ceiling is off by default: cargo-sweep measures apparent file size, not the allocated size `du` reports. One workspace here measures 20.9 GiB by `du` and 32.9 GiB to cargo-sweep, so a ceiling picked against `du` would trim a healthy tree on every run.

Close-out not run: shell and config only, no Rust source changed.